### PR TITLE
doc: Use verbs ending in s for functions/methods

### DIFF
--- a/pybricks/builtins.py
+++ b/pybricks/builtins.py
@@ -23,7 +23,7 @@ class DCMotor:
         pass
 
     def dc(self, duty):
-        """Rotate the motor at a given duty cycle (also known as "power").
+        """Rotates the motor at a given duty cycle (also known as "power").
 
         Arguments:
             duty (:ref:`percentage`): The duty cycle (-100.0 to 100).
@@ -31,13 +31,13 @@ class DCMotor:
         pass
 
     def stop(self):
-        """Stop the motor and let it spin freely.
+        """Stops the motor and let it spin freely.
 
         The motor gradually stops due to friction."""
         pass
 
     def brake(self):
-        """Passively brake the motor.
+        """Passively brakes the motor.
 
         The motor stops due to friction, plus the voltage that
         is generated while the motor is still moving."""
@@ -55,7 +55,7 @@ class Control:
     """
 
     def limits(self, speed, acceleration, actuation):
-        """Configure the maximum speed, acceleration, and actuation.
+        """Configures the maximum speed, acceleration, and actuation.
 
         If no arguments are given, this will return the current values.
 
@@ -70,7 +70,7 @@ class Control:
         pass
 
     def pid(self, kp, ki, kd, integral_range, integral_rate, feed_forward):
-        """Get or set the PID values for position and speed control.
+        """Gets or sets the PID values for position and speed control.
 
         If no arguments are given, this will return the current values.
 
@@ -93,7 +93,7 @@ class Control:
         pass
 
     def target_tolerances(self, speed, position):
-        """Get or set the tolerances that say when a maneuver is done.
+        """Gets or sets the tolerances that say when a maneuver is done.
 
         If no arguments are given, this will return the current values.
 
@@ -107,7 +107,7 @@ class Control:
         pass
 
     def stall_tolerances(self, speed, time):
-        """Get or set stalling tolerances.
+        """Gets or sets stalling tolerances.
 
         If no arguments are given, this will return the current values.
 
@@ -121,7 +121,7 @@ class Control:
         pass
 
     def stalled(self):
-        """Check whether the controller is currently stalled.
+        """Checks if the controller is currently stalled.
 
         A controller is stalled when it cannot reach the target speed or
         position, even with the maximum actuation signal.
@@ -132,7 +132,7 @@ class Control:
         pass
 
     def done(self):
-        """Check whether an ongoing command or maneuver is done.
+        """Checks if an ongoing command or maneuver is done.
 
         Returns:
             bool: ``True`` if the command is done, ``False`` if not.
@@ -174,7 +174,7 @@ class Motor(DCMotor):
         pass
 
     def angle(self):
-        """Get the rotation angle of the motor.
+        """Gets the rotation angle of the motor.
 
         Returns:
             :ref:`angle`: Motor angle.
@@ -183,7 +183,7 @@ class Motor(DCMotor):
         pass
 
     def speed(self):
-        """Get the speed of the motor.
+        """Gets the speed of the motor.
 
         Returns:
             :ref:`speed`: Motor speed.
@@ -192,7 +192,7 @@ class Motor(DCMotor):
         pass
 
     def reset_angle(self, angle):
-        """Reset the accumulated rotation angle of the motor.
+        """Resets the accumulated rotation angle of the motor.
 
         Arguments:
             angle (:ref:`angle`): Value to which the angle should be reset.
@@ -200,11 +200,11 @@ class Motor(DCMotor):
         pass
 
     def hold(self):
-        """Stop the motor and actively hold it at its current angle."""
+        """Stops the motor and actively holds it at its current angle."""
         pass
 
     def run(self, speed):
-        """Keep the motor running at a constant speed.
+        """Keeps the motor running at a constant speed.
 
         The motor keeps running until you give a new command.
 
@@ -214,7 +214,7 @@ class Motor(DCMotor):
         pass
 
     def run_time(self, speed, time, then=Stop.HOLD, wait=True):
-        """Run the motor at a constant speed for a given amount of time.
+        """Runs the motor at a constant speed for a given amount of time.
 
         Arguments:
             speed (:ref:`speed`): Speed of the motor.
@@ -226,7 +226,7 @@ class Motor(DCMotor):
         pass
 
     def run_angle(self, speed, rotation_angle, then=Stop.HOLD, wait=True):
-        """Run the motor at a constant speed by a given angle.
+        """Runs the motor at a constant speed by a given angle.
 
         Arguments:
             speed (:ref:`speed`): Speed of the motor.
@@ -239,7 +239,7 @@ class Motor(DCMotor):
         pass
 
     def run_target(self, speed, target_angle, then=Stop.HOLD, wait=True):
-        """ Run the motor at a constant speed towards a
+        """Runs the motor at a constant speed towards a
         given target angle.
 
         The direction of rotation is automatically selected based on the target
@@ -257,7 +257,7 @@ class Motor(DCMotor):
         pass
 
     def run_until_stalled(self, speed, then=Stop.COAST, duty_limit=None):
-        """Run the motor at a constant speed until it
+        """Runs the motor at a constant speed until it
         :ref:`stalls <stalled>`
 
         Arguments:
@@ -270,7 +270,7 @@ class Motor(DCMotor):
         pass
 
     def track_target(self, target_angle):
-        """Track a target angle. This is similar to :meth:`.run_target`, but
+        """Tracks a target angle. This is similar to :meth:`.run_target`, but
         the usual smooth acceleration is skipped: it will move to the target
         angle as fast as possible. This method is useful if you want to
         continuously change the target angle.
@@ -283,7 +283,7 @@ class Motor(DCMotor):
         pass
 
     def dc(self, duty):
-        """Rotate the motor at a given duty cycle (also known as "power").
+        """Rotates the motor at a given duty cycle (also known as "power").
 
         This method lets you use a motor just like a simple DC motor.
 
@@ -293,7 +293,7 @@ class Motor(DCMotor):
 
 
 class Speaker:
-    """Play beeps and sounds using a speaker."""
+    """Plays beeps and sounds using a speaker."""
 
     def beep(self, frequency=500, duration=100):
         """Play a beep/tone.
@@ -310,7 +310,7 @@ class Speaker:
         pass
 
     def play_notes(self, notes, tempo=120):
-        """Play a sequence of musical notes.
+        """Plays a sequence of musical notes.
 
         For example, you can play: ``['C4/4', 'C4/4', 'G4/4', 'G4/4']``.
 
@@ -323,7 +323,7 @@ class Speaker:
         pass
 
     def play_file(self, file_name):
-        """Play a sound file.
+        """Plays a sound file.
 
         Arguments:
             file_name (str):
@@ -333,7 +333,7 @@ class Speaker:
         pass
 
     def say(self, text):
-        """Say a given text string.
+        """Says a given text string.
 
         You can configure the language and voice of the text using
         :meth:`set_speech_options`.
@@ -345,7 +345,7 @@ class Speaker:
         pass
 
     def set_speech_options(self, language=None, voice=None, speed=None, pitch=None):
-        """Configure speech settings used by the :meth:`say` method.
+        """Configures speech settings used by the :meth:`say` method.
 
         Any option that is set to ``None`` will not be changed. If an option
         is set to an invalid value :meth:`say` will use the default value
@@ -369,7 +369,7 @@ class Speaker:
         pass
 
     def set_volume(self, volume, which='_all_'):
-        """Set the speaker volume.
+        """Sets the speaker volume.
 
         Arguments:
             volume (:ref:`percentage`):
@@ -395,7 +395,7 @@ class Light:
         """
 
     def off(self):
-        """Turn off the light."""
+        """Turns off the light."""
         pass
 
 
@@ -403,7 +403,7 @@ class ColorLight:
     """Control a multi-color light."""
 
     def on(self, color):
-        """Turn on the light at the specified color.
+        """Turns on the light at the specified color.
 
         Arguments:
             color (Color): Color of the light. The light turns off if you
@@ -412,11 +412,11 @@ class ColorLight:
         pass
 
     def off(self):
-        """Turn off the light."""
+        """Turns off the light."""
         pass
 
     def rgb(self, red, green, blue):
-        """Set the brightness of the red, green, and blue light.
+        """Sets the brightness of the red, green, and blue light.
 
         Arguments:
             red (:ref:`brightness`): Brightness of the red light.
@@ -430,7 +430,7 @@ class LightArray:
     """Control an array of single-color lights."""
 
     def __init__(self, lights):
-        """Initialize the light array.
+        """Initializes the light array.
 
         Arguments:
             lights (int): Number of lights
@@ -438,7 +438,7 @@ class LightArray:
         pass
 
     def on(self, brightness=100):
-        """Turn on all the lights at the specified brightness.
+        """Turns on all the lights at the specified brightness.
 
         Arguments:
             brightness (:ref:`brightness`):
@@ -447,13 +447,13 @@ class LightArray:
         pass
 
     def off(self):
-        """Turn off all the lights."""
+        """Turns off all the lights."""
         pass
 
     def array(self, *brightnesses):
         """array(first_light, ..., last_light)
 
-        Set the brightness of each light individually.
+        Sets the brightness of each light individually.
 
         Arguments:
             brightness (:ref:`brightness`, ..., :ref:`brightness`):
@@ -466,7 +466,7 @@ class LightGrid:
     """Control a rectangular grid of single-color lights."""
 
     def __init__(self, rows, columns):
-        """Initialize the light grid.
+        """Initializes the light grid.
 
         Arguments:
             rows (int): Number of rows in the grid
@@ -475,7 +475,7 @@ class LightGrid:
         pass
 
     def image(self, matrix, clear=True):
-        """Show an image made up of pixels of a given brightness.
+        """Shows an image made up of pixels of a given brightness.
 
         Arguments:
             matrix (2D Array): Matrix of intensities (:ref:`brightness`).
@@ -486,7 +486,7 @@ class LightGrid:
         pass
 
     def pixel(self, row, column, brightness):
-        """Turn on a pixel at the specified brightness.
+        """Turns on a pixel at the specified brightness.
 
         Arguments:
             row (int): Vertical grid index, starting at 0 from the top.
@@ -496,7 +496,7 @@ class LightGrid:
         pass
 
     def on(self, brightness=100):
-        """Turn on all the pixels at the specified brightness.
+        """Turns on all the pixels at the specified brightness.
 
         Arguments:
             brightness (:ref:`brightness`):
@@ -505,11 +505,11 @@ class LightGrid:
         pass
 
     def off(self):
-        """Turn off all the pixels."""
+        """Turns off all the pixels."""
         pass
 
     def number(self, number):
-        """Display a number on the light grid.
+        """Displays a number on the light grid.
 
         Arguments:
             number (int): The number to be displayed.
@@ -517,7 +517,7 @@ class LightGrid:
         pass
 
     def char(self, character):
-        """Display a character or symbol on the light grid. This may
+        """Displays a character or symbol on the light grid. This may
         be any letter (``a``--``z``), capital letter (``A``--``Z``) or one of
         the following symbols: ``!"#$%&'()*+,-./:;<=>?@[\\]^_`{|}``.
 
@@ -527,7 +527,7 @@ class LightGrid:
         pass
 
     def text(self, text, pause=500):
-        """Display a text string, one character at a time, with a pause
+        """Displays a text string, one character at a time, with a pause
         between each character. After the last character is shown, the light
         grid turns off.
 
@@ -543,7 +543,7 @@ class KeyPad:
     """Get status of buttons on a keypad layout."""
 
     def pressed(self):
-        """Check which buttons are currently pressed.
+        """Checks which buttons are currently pressed.
 
         :returns: List of pressed buttons.
         :rtype: List of :class:`Button <.parameters.Button>`
@@ -556,7 +556,7 @@ class Battery:
     """Get the status of a battery."""
 
     def voltage(self):
-        """Get the voltage of the battery.
+        """Gets the voltage of the battery.
 
         Returns:
             :ref:`voltage`: Battery voltage.
@@ -564,7 +564,7 @@ class Battery:
         pass
 
     def current(self):
-        """Get the current supplied by the battery.
+        """Gets the current supplied by the battery.
 
         Returns:
             :ref:`current`: Battery current.
@@ -577,7 +577,7 @@ class Accelerometer:
     """Get measurements from an accelerometer."""
 
     def neutral(self, top, front):
-        """Configure the neutral orientation of the device or hub. You do this
+        """Configures the neutral orientation of the device or hub. You do this
         by specifying how it is mounted on your design, in terms of the
         :ref:`robot reference frame <robotframe>`.
 
@@ -597,7 +597,7 @@ class Accelerometer:
     def acceleration(self, axis=Axis.ALL):
         """acceleration(axis=Axis.ALL)
 
-        Measure the acceleration of the device along a given axis in the
+        Gets the acceleration of the device along a given axis in the
         :ref:`robot reference frame <robotframe>`.
 
         Arguments:
@@ -613,7 +613,7 @@ class Accelerometer:
         pass
 
     def tilt(self):
-        """Get the pitch and roll angles relative to the neutral, horizontal
+        """Gets the pitch and roll angles relative to the neutral, horizontal
         orientation.
 
         The order of rotation is pitch-then-roll. This is equivalent to a
@@ -627,7 +627,7 @@ class Accelerometer:
         pass
 
     def tapped(self):
-        """Check if the device or hub was tapped.
+        """Checks if the device or hub was tapped.
 
         Returns:
             bool:
@@ -639,7 +639,7 @@ class Accelerometer:
         pass
 
     def shaken(self):
-        """Check if the device or hub was shaken.
+        """Checks if the device or hub was shaken.
 
         Returns:
             bool:
@@ -651,7 +651,7 @@ class Accelerometer:
         pass
 
     def up(self):
-        """Check which side of the device or hub currently faces upward.
+        """Checks which side of the device or hub currently faces upward.
 
         :returns:
             ``Side.TOP``, ``Side.BOTTOM``, ``Side.LEFT``, ``Side.RIGHT``,
@@ -665,7 +665,7 @@ class Accelerometer:
 class IMU(Accelerometer):
 
     def heading(self):
-        """Get the heading angle relative to the starting orientation. It is a
+        """Gets the heading angle relative to the starting orientation. It is a
         a positive rotation around the :ref:`z-axis in the robot
         frame <robotframe>`, prior to applying any tilt rotation.
 
@@ -679,7 +679,7 @@ class IMU(Accelerometer):
         pass
 
     def reset_heading(self, angle):
-        """Reset the accumulated heading angle of the robot.
+        """Resets the accumulated heading angle of the robot.
 
         Arguments:
             angle (:ref:`angle`): Value to which the heading should be reset.
@@ -689,7 +689,7 @@ class IMU(Accelerometer):
     def gyro(self, axis=Axis.ALL):
         """gyro(axis=Axis.ALL)
 
-        Measure the angular velocity of the device along a given axis in the
+        Measures the angular velocity of the device along a given axis in the
         :ref:`robot reference frame <robotframe>`.
 
         Arguments:

--- a/pybricks/ev3devices.py
+++ b/pybricks/ev3devices.py
@@ -19,7 +19,7 @@ class TouchSensor:
         pass
 
     def pressed(self):
-        """Check if the sensor is pressed.
+        """Checks if the sensor is pressed.
 
         Returns:
             bool: ``True`` if the sensor is pressed, ``False`` if it is
@@ -42,7 +42,7 @@ class ColorSensor:
         pass
 
     def color(self):
-        """Measure the color of a surface.
+        """Measures the color of a surface.
 
         :returns:
             ``Color.BLACK``, ``Color.BLUE``, ``Color.GREEN``, ``Color.YELLOW``,
@@ -54,7 +54,7 @@ class ColorSensor:
         pass
 
     def ambient(self):
-        """Measure the ambient light intensity.
+        """Measures the ambient light intensity.
 
         Returns:
             :ref:`percentage`: Ambient light intensity, ranging from 0 (dark)
@@ -63,7 +63,7 @@ class ColorSensor:
         pass
 
     def reflection(self):
-        """Measure the reflection of a surface using a red light.
+        """Measures the reflection of a surface using a red light.
 
         Returns:
             :ref:`percentage`: Reflection, ranging from 0 (no reflection) to
@@ -73,7 +73,7 @@ class ColorSensor:
         pass
 
     def rgb(self):
-        """Measure the reflection of a surface using a red, green, and then a
+        """Measures the reflection of a surface using a red, green, and then a
         blue light.
 
         Returns:
@@ -97,7 +97,7 @@ class InfraredSensor:
         pass
 
     def distance(self):
-        """Measure the relative distance between the sensor and an object using
+        """Measures the relative distance between the sensor and an object using
         infrared light.
 
         Returns:
@@ -108,7 +108,7 @@ class InfraredSensor:
         pass
 
     def beacon(self, channel):
-        """Measure the relative distance and angle between the remote and the
+        """Measures the relative distance and angle between the remote and the
         infrared sensor.
 
         Arguments:
@@ -122,7 +122,7 @@ class InfraredSensor:
         pass
 
     def buttons(self, channel):
-        """Check which buttons on the infrared remote are pressed.
+        """Checks which buttons on the infrared remote are pressed.
 
         This method can detect up to two buttons at once. If you press
         more buttons, you may not get useful data.
@@ -137,7 +137,7 @@ class InfraredSensor:
         pass
 
     def keypad(self):
-        """Check which buttons on the infrared remote are pressed.
+        """Checks which buttons on the infrared remote are pressed.
 
         This method can independently detect all 4 up/down buttons, but
         it cannot detect the beacon button.
@@ -167,7 +167,7 @@ class GyroSensor:
         pass
 
     def speed(self):
-        """Get the speed (angular velocity) of the sensor.
+        """Gets the speed (angular velocity) of the sensor.
 
         Returns:
             :ref:`speed`: Sensor angular velocity.
@@ -176,7 +176,7 @@ class GyroSensor:
         pass
 
     def angle(self):
-        """Get the accumulated angle of the sensor.
+        """Gets the accumulated angle of the sensor.
 
         Returns:
             :ref:`angle`: Rotation angle.
@@ -185,7 +185,7 @@ class GyroSensor:
         pass
 
     def reset_angle(self, angle):
-        """Set the rotation angle of the sensor to a desired value.
+        """Sets the rotation angle of the sensor to a desired value.
 
         If you don't specify an angle, the absolute value will be used if
         available.
@@ -196,7 +196,7 @@ class GyroSensor:
         pass
 
     def _calibrate(self):
-        """Calibrate the sensor.
+        """Calibrates the sensor.
 
         This process sets the speed and angle to zero and ensures that the
         angle value does not drift.
@@ -221,7 +221,7 @@ class UltrasonicSensor:
         pass
 
     def distance(self, silent=False):
-        """Measure the distance between the sensor and an object using
+        """Measures the distance between the sensor and an object using
         ultrasonic sound waves.
 
         Arguments:
@@ -241,7 +241,7 @@ class UltrasonicSensor:
         pass
 
     def presence(self):
-        """Check for the presence of other ultrasonic sensors by detecting
+        """Checks for the presence of other ultrasonic sensors by detecting
         ultrasonic sounds.
 
         If the other ultrasonic sensor is operating in silent mode, you can

--- a/pybricks/iodevices.py
+++ b/pybricks/iodevices.py
@@ -16,7 +16,7 @@ class LUMPDevice:
         pass
 
     def read(self, mode):
-        """Read values from a given mode.
+        """Reads values from a given mode.
 
         Arguments:
             mode (``int``): Device mode.
@@ -27,7 +27,7 @@ class LUMPDevice:
         pass
 
     def write(self, mode, values):
-        """Write values to the sensor. Only selected sensors and modes support
+        """Writes values to the sensor. Only selected sensors and modes support
         this.
 
         Arguments:
@@ -55,7 +55,7 @@ class Ev3devSensor:
         pass
 
     def read(self, mode):
-        """Read values at a given mode.
+        """Reads values at a given mode.
 
         Arguments:
             mode (``str``): `Mode name`_.
@@ -78,7 +78,7 @@ class AnalogSensor:
         pass
 
     def voltage(self):
-        """Measured analog voltage.
+        """Measures analog voltage.
 
         Returns:
             :ref:`voltage`: Analog voltage.
@@ -86,7 +86,7 @@ class AnalogSensor:
         pass
 
     def resistance(self):
-        """Measured resistance.
+        """Measures resistance.
 
         This value is only meaningful if the analog device is a passive load
         such as a resistor or thermistor.
@@ -97,7 +97,7 @@ class AnalogSensor:
         pass
 
     def active(self):
-        """Set sensor to active mode. This sets pin 5 of the sensor
+        """Sets sensor to active mode. This sets pin 5 of the sensor
         port to `high`.
 
         This is used in some analog
@@ -108,7 +108,7 @@ class AnalogSensor:
         pass
 
     def passive(self):
-        """Set sensor to passive mode. This sets pin 5 of the sensor
+        """Sets sensor to passive mode. This sets pin 5 of the sensor
         port to `low`.
 
         This is used in some analog
@@ -133,7 +133,7 @@ class I2CDevice:
         pass
 
     def read(self, reg, length=1):
-        """Read bytes, starting at a given register.
+        """Reads bytes, starting at a given register.
 
         Arguments:
             reg (``int``): Register at which to begin
@@ -146,7 +146,7 @@ class I2CDevice:
         pass
 
     def write(self, reg, data=None):
-        """Write bytes, starting at a given register.
+        """Writes bytes, starting at a given register.
 
         Arguments:
             reg (``int``): Register at which to begin
@@ -172,7 +172,7 @@ class UARTDevice:
         pass
 
     def read(self, length=1):
-        """Read a given number of bytes from the buffer.
+        """Reads a given number of bytes from the buffer.
 
         Your program will wait until the requested number of bytes are
         received. If this takes longer than ``timeout``, the ``ETIMEDOUT``
@@ -187,7 +187,7 @@ class UARTDevice:
         pass
 
     def read_all(self):
-        """Read all bytes from the buffer.
+        """Reads all bytes from the buffer.
 
         Returns:
             ``bytes``: Bytes returned from the device.
@@ -195,7 +195,7 @@ class UARTDevice:
         pass
 
     def write(self, data):
-        """Write bytes.
+        """Writes bytes.
 
         Arguments:
             data (``bytes``): Bytes to be written.
@@ -203,7 +203,7 @@ class UARTDevice:
         pass
 
     def waiting(self):
-        """How many bytes are still waiting to be read.
+        """Gets how many bytes are still waiting to be read.
 
         Returns:
             ``int``: Number of bytes in the buffer.
@@ -211,5 +211,5 @@ class UARTDevice:
         pass
 
     def clear(self):
-        """Empty the buffer."""
+        """Empties the buffer."""
         pass

--- a/pybricks/nxtdevices.py
+++ b/pybricks/nxtdevices.py
@@ -20,7 +20,7 @@ class TouchSensor:
         pass
 
     def pressed(self):
-        """Check if the sensor is pressed.
+        """Checks if the sensor is pressed.
 
         Returns:
             bool: ``True`` if the sensor is pressed, ``False`` if it is
@@ -43,7 +43,7 @@ class LightSensor:
         pass
 
     def ambient(self):
-        """Measure the ambient light intensity.
+        """Measures the ambient light intensity.
 
         Returns:
             :ref:`percentage`: Ambient light intensity, ranging from 0 (dark)
@@ -52,7 +52,7 @@ class LightSensor:
         pass
 
     def reflection(self):
-        """Measure the reflection of a surface using a red light.
+        """Measures the reflection of a surface using a red light.
 
         Returns:
             :ref:`percentage`: Reflection, ranging from 0 (no reflection) to
@@ -77,7 +77,7 @@ class ColorSensor:
         pass
 
     def color(self):
-        """Measure the color of a surface.
+        """Measures the color of a surface.
 
         :returns:
             ``Color.BLACK``, ``Color.BLUE``, ``Color.GREEN``, ``Color.YELLOW``,
@@ -89,7 +89,7 @@ class ColorSensor:
         pass
 
     def ambient(self):
-        """Measure the ambient light intensity.
+        """Measures the ambient light intensity.
 
         Returns:
             :ref:`percentage`: Ambient light intensity, ranging from 0 (dark)
@@ -98,7 +98,7 @@ class ColorSensor:
         pass
 
     def reflection(self):
-        """Measure the reflection of a surface.
+        """Measures the reflection of a surface.
 
         Returns:
             :ref:`percentage`: Reflection, ranging from 0 (no reflection) to
@@ -108,7 +108,7 @@ class ColorSensor:
         pass
 
     def rgb(self):
-        """Measure the reflection of a surface using a red, green, and then a
+        """Measures the reflection of a surface using a red, green, and then a
         blue light.
 
         Returns:
@@ -132,7 +132,7 @@ class UltrasonicSensor:
         pass
 
     def distance(self):
-        """Measure the distance between the sensor and an object using
+        """Measures the distance between the sensor and an object using
         ultrasonic sound waves.
 
         Returns:
@@ -155,7 +155,7 @@ class SoundSensor:
         pass
 
     def intensity(self, audible_only=True):
-        """Measure the ambient sound intensity (loudness).
+        """Measures the ambient sound intensity (loudness).
 
         Arguments:
             audible_only (bool): Detect only audible sounds. This tries to
@@ -182,7 +182,7 @@ class TemperatureSensor:
         pass
 
     def temperature(self):
-        """Measure the temperature.
+        """Measures the temperature.
 
         Returns:
             :ref:`temperature`: Measured temperature.
@@ -204,7 +204,7 @@ class EnergyMeter:
         pass
 
     def storage(self):
-        """Get the total available energy stored in the battery.
+        """Gets the total available energy stored in the battery.
 
         Returns:
             :ref:`energy`: Remaining stored energy.
@@ -213,7 +213,7 @@ class EnergyMeter:
         pass
 
     def input(self):
-        """This measures the electrical signals at the input (bottom) side
+        """Measures the electrical signals at the input (bottom) side
         of the energy meter. It measures the voltage applied to it and the
         current passing through it. The product of these two values is power.
         This power value is the rate at which the stored energy increases. This
@@ -228,7 +228,7 @@ class EnergyMeter:
         pass
 
     def output(self):
-        """This measures the electrical signals at the output (top) side
+        """Measures the electrical signals at the output (top) side
         of the energy meter. It measures the voltage applied to the external
         load and the current passing to it. The product of these two values
         is power. This power value is the rate at which the stored energy
@@ -260,7 +260,7 @@ class VernierAdapter(AnalogSensor):
         pass
 
     def voltage(self):
-        """Measure the raw analog sensor voltage.
+        """Measures the raw analog sensor voltage.
 
         Returns:
             :ref:`voltage`: Analog voltage.
@@ -268,8 +268,7 @@ class VernierAdapter(AnalogSensor):
         pass
 
     def conversion(self, voltage):
-        """User-supplied function that converts the raw voltage (mV) to a
-        sensor value.
+        """Converts the raw voltage (mV) to a sensor value.
 
         If you did not provide a ``conversion`` function earlier, no conversion
         will be applied.
@@ -283,7 +282,7 @@ class VernierAdapter(AnalogSensor):
         pass
 
     def value(self):
-        """This method measures the sensor :meth:`.voltage` and then
+        """Measures the sensor :meth:`.voltage` and then
         applies your :meth:`.conversion` to give you the sensor value.
 
         :returns: Converted sensor value.

--- a/pybricks/pupdevices.py
+++ b/pybricks/pupdevices.py
@@ -53,7 +53,7 @@ class ColorDistanceSensor:
         pass
 
     def color(self):
-        """Measure the color of a surface.
+        """Measures the color of a surface.
 
         :returns:
             ``Color.BLACK``, ``Color.BLUE``, ``Color.GREEN``, ``Color.YELLOW``,
@@ -64,7 +64,7 @@ class ColorDistanceSensor:
         pass
 
     def ambient(self):
-        """Measure the ambient light intensity.
+        """Measures the ambient light intensity.
 
         Returns:
             :ref:`percentage`: Ambient light intensity, ranging from 0 (dark)
@@ -73,7 +73,7 @@ class ColorDistanceSensor:
         pass
 
     def reflection(self):
-        """Measure the reflection of a surface using a red light.
+        """Measures the reflection of a surface using a red light.
 
         Returns:
             :ref:`percentage`: Reflection, ranging from 0.0 (no reflection) to
@@ -82,7 +82,7 @@ class ColorDistanceSensor:
         pass
 
     def rgb(self):
-        """Measure the reflection of a surface using a red, green, and then a
+        """Measures the reflection of a surface using a red, green, and then a
         blue light.
 
         Returns:
@@ -93,7 +93,7 @@ class ColorDistanceSensor:
         pass
 
     def distance(self):
-        """Measure the relative distance between the sensor and an object using
+        """Measures the relative distance between the sensor and an object using
         infrared light.
 
         Returns:

--- a/pybricks/robotics.py
+++ b/pybricks/robotics.py
@@ -34,7 +34,7 @@ class DriveBase:
         """
 
     def drive(self, drive_speed, turn_rate):
-        """Start driving at the specified speed and turn rate. Both values are
+        """Starts driving at the specified speed and turn rate. Both values are
         measured at the center point between the wheels of the robot.
 
         Arguments:
@@ -46,11 +46,11 @@ class DriveBase:
         pass
 
     def stop(self):
-        """Stop the robot by letting the motors spin freely."""
+        """Stops the robot by letting the motors spin freely."""
         pass
 
     def distance(self):
-        """Get the estimated driven distance.
+        """Gets the estimated driven distance.
 
         Returns:
             :ref:`distance`: Driven distance since last reset.
@@ -58,7 +58,7 @@ class DriveBase:
         pass
 
     def angle(self):
-        """Get the estimated rotation angle of the drive base.
+        """Gets the estimated rotation angle of the drive base.
 
         Returns:
             :ref:`angle`: Accumulated angle since last reset.
@@ -66,7 +66,7 @@ class DriveBase:
         pass
 
     def state(self):
-        """Get the state of the robot.
+        """Gets the state of the robot.
 
         This returns the current :meth:`.distance`, the drive speed, the
         :meth:`.angle`, and the turn rate.
@@ -77,12 +77,12 @@ class DriveBase:
         pass
 
     def reset(self):
-        """Reset the estimated driven distance and angle to 0."""
+        """Resets the estimated driven distance and angle to 0."""
         pass
 
     def settings(self, straight_speed, straight_acceleration, turn_rate,
                  turn_acceleration):
-        """Configure the speed and acceleration used
+        """Configures the speed and acceleration used
         by :meth:`.straight` and :meth:`.turn`.
 
         If you give no arguments, this returns the current values as a tuple.
@@ -105,7 +105,7 @@ class DriveBase:
         pass
 
     def straight(self, distance):
-        """Drive straight for a given distance and then stop.
+        """Drives straight for a given distance and then stops.
 
         Arguments:
             distance (:ref:`distance`): Distance to travel.
@@ -113,7 +113,7 @@ class DriveBase:
         pass
 
     def turn(self, angle):
-        """Turn in place by a given angle and then stop.
+        """Turns in place by a given angle and then stops.
 
         Arguments:
             angle (:ref:`angle`): Angle of the turn.

--- a/pybricks/tools.py
+++ b/pybricks/tools.py
@@ -5,7 +5,7 @@
 
 
 def wait(time):
-    """Pause the user program for a specified amount of time.
+    """Pauses the user program for a specified amount of time.
 
     Arguments:
         time (:ref:`time`): How long to wait.
@@ -22,7 +22,7 @@ class StopWatch:
         pass
 
     def time(self):
-        """Get the current time of the stopwatch.
+        """Gets the current time of the stopwatch.
 
         Returns:
             :ref:`time`: Elapsed time.
@@ -30,15 +30,15 @@ class StopWatch:
         pass
 
     def pause(self):
-        """Pause the stopwatch."""
+        """Pauses the stopwatch."""
         pass
 
     def resume(self):
-        """Resume the stopwatch."""
+        """Resumes the stopwatch."""
         pass
 
     def reset(self):
-        """Reset the stopwatch time to 0.
+        """Resets the stopwatch time to 0.
 
         The run state is unaffected:
 
@@ -67,7 +67,7 @@ class DataLog:
         pass
 
     def log(self, *values):
-        """Save one or more values on a new line in the file.
+        """Saves one or more values on a new line in the file.
 
         Arguments:
             values (object, object, `...`): One or more objects or values.


### PR DESCRIPTION
The documentation currently has a mix of with and without the `s`. Adding an `s` is consistent with most API documentation in general, especially more modern documentation.