### PR TITLE
doc: add external link decoration to sidebar

### DIFF
--- a/doc/common/_static/css/theme_overrides.css
+++ b/doc/common/_static/css/theme_overrides.css
@@ -36,3 +36,13 @@ span.caption-number:after {
         max-width: 800px;
     }
 }
+
+/* decorate external links in navigation side bar */
+.wy-nav-side a.reference.external:after {
+    font-family: FontAwesome;
+    content: "";
+    color: #b3b3b3;
+    vertical-align: super;
+    font-size: 60%;
+    margin: 0 0.2em;
+}


### PR DESCRIPTION
External link decorations are already enabled in the documentation content, but the RTD theme doesn't extend this to the sidebar. This copies the css from the RTD theme and adds it to the sidebar.

This makes it less of a surprise when you click on a link and find yourself on a completely different website.

![image](https://user-images.githubusercontent.com/963645/77568226-4e896b80-6e96-11ea-834f-9a367099acf0.png)
