### PR TITLE
Lights and patterns

### DIFF
--- a/doc/api/hubs_cityhub.inc
+++ b/doc/api/hubs_cityhub.inc
@@ -7,6 +7,12 @@
 
     .. automethod:: pybricks.hubs::CityHub.light.off
 
+..    .. automethod:: pybricks.hubs::CityHub.light.hsv
+
+..    .. automethod:: pybricks.hubs::CityHub.light.pattern
+
+..    .. automethod:: pybricks.hubs::CityHub.light.reset
+
     .. rubric:: Using the battery
 
     .. automethod:: pybricks.hubs::CityHub.battery.voltage

--- a/doc/api/pupdevices.rst
+++ b/doc/api/pupdevices.rst
@@ -248,3 +248,5 @@ Light
     .. automethod:: pybricks.pupdevices.Light.on
 
     .. automethod:: pybricks.pupdevices.Light.off
+
+..    .. automethod:: pybricks.pupdevices.Light.pattern

--- a/doc/api/signaltypes.rst
+++ b/doc/api/signaltypes.rst
@@ -242,3 +242,11 @@ Fahrenheit (°F) or Kelvin (K), you can use the following conversion formulas:
     :math:`°\!F = °\!C \cdot \frac{9}{5} + 32`.
 
     :math:`K = °\!C + 273.15`.
+
+.. _hue:
+
+hue: deg
+--------------
+Hue of a color (0-359 degrees).
+
+TODO: diagram

--- a/pybricks/_common.py
+++ b/pybricks/_common.py
@@ -448,7 +448,7 @@ class ColorLight:
         """Set the hue, saturation and brightness of the light.
 
         Arguments:
-            hue (:ref:`angle`): Hue of the color.
+            hue (:ref:`hue`): Hue of the color.
             saturation (:ref:`percentage`): Saturation of the color.
             value (:ref:`percentage`): Brightness value of the color.
         """

--- a/pybricks/_common.py
+++ b/pybricks/_common.py
@@ -471,19 +471,39 @@ class LightGrid:
         """
         pass
 
-    def image(self, matrix, clear=True):
-        """Shows an image made up of pixels of a given brightness.
+    def image(self, binary, clear=True):
+        """Shows an image made up of pixels of full brightness, represented by
+        a single number.
+
+        You can use one of the built-in example images or make your own.
+
+        Arguments:
+            binary (int): Binary number representing the image. Each bit is one
+                pixel, where 1 means on and 0 means off. The least significant
+                bit is the last pixel.
+            clear (bool): Whether to turn off all the lights before showing
+                the new image. If you choose ``False``,
+                the given matrix is added to the one already shown.
+        """
+        pass
+
+    def matrix(self, matrix, clear=True):
+        """Shows an image made up of pixels of a given brightness, represented
+        by a matrix of intensity values.
+
+        Compared to :meth:`.image` you can make more refined images, but this
+        method is slower and uses more memory.
 
         Arguments:
             matrix (2D Array): Matrix of intensities (:ref:`brightness`).
             clear (bool): Whether to turn off all the lights before showing
                 the new image. If you choose ``False``,
-                the given matrix is added to one already shown.
+                the given matrix is added to the one already shown.
         """
         pass
 
     def pixel(self, row, column, brightness):
-        """Turns on a pixel at the specified brightness.
+        """Turns on one pixel at the specified brightness.
 
         Arguments:
             row (int): Vertical grid index, starting at 0 from the top.
@@ -509,7 +529,7 @@ class LightGrid:
         """Displays a number on the light grid.
 
         Arguments:
-            number (int): The number to be displayed.
+            number (int): The number to be displayed (0--99).
         """
         pass
 

--- a/pybricks/_common.py
+++ b/pybricks/_common.py
@@ -422,6 +422,11 @@ class Light:
             time (:ref:`time`): Duration of the pattern.
         """
 
+    def reset(self):
+        """Resets the light to the default system behavior."""
+        # This method is exposed on system lights only.
+        pass
+
 
 class ColorLight:
     """Control a multi-color light."""
@@ -467,6 +472,11 @@ class ColorLight:
                 a :class:`Button <.parameters.Color>` for simplicity.
             time (:ref:`time`): Duration of the pattern.
         """
+
+    def reset(self):
+        """Resets the light to the default system behavior."""
+        # This method is exposed on system lights only.
+        pass
 
 
 class LightArray:
@@ -587,9 +597,13 @@ class LightGrid:
 
         Arguments:
             character (str): The character or symbol to be displayed.
-            time (:ref:`time`): How long to show a character before showing
-                                the next one.
+            pause (:ref:`time`): How long to show a character before showing
+                                 the next one.
         """
+        pass
+
+    def reset(self):
+        """Resets the light grid to the default system behavior."""
         pass
 
 

--- a/pybricks/_common.py
+++ b/pybricks/_common.py
@@ -450,6 +450,27 @@ class ColorLight:
         """
         pass
 
+    def pattern(self, pattern, duration, repeat=True):
+        """Make the light follow a color pattern as a function of time.
+
+        The specified pattern function will be sampled at 64 points between 0
+        and the specified duration. The light will be held constant between
+        samples.
+
+        This function is not blocking. The pattern will be shown as the
+        user program continues.
+
+        Arguments:
+            pattern (callable): Function of the
+                form ``h, s, v = func(t)``` that returns a tuple of ``h``,
+                ``s``, and ``v`` as a function of time ``t`` in milliseconds.
+                Instead of an HSV tuple, you may return
+                a :class:`Button <.parameters.Color>` for simplicity.
+            time (:ref:`time`): Duration of the pattern.
+            repeat (bool): Whether to keep repeating the pattern after it
+                completes.
+        """
+
 
 class LightArray:
     """Control an array of single-color lights."""

--- a/pybricks/_common.py
+++ b/pybricks/_common.py
@@ -404,6 +404,25 @@ class Light:
         """Turns off the light."""
         pass
 
+    def pattern(self, pattern, duration, repeat=True):
+        """Make the light brightness follow a pattern as a function of time.
+
+        The specified pattern function will be sampled at 64 points between 0
+        and the specified duration. The light will be held at a constant
+        brightness between samples.
+
+        This function is not blocking. The pattern will be shown as the
+        user program continues.
+
+        Arguments:
+            pattern (callable): Function of the
+                form ``b = func(t)``` that returns the brightness ``b``
+                of the (0--100.0) as a function of time ``t`` in milliseconds.
+            time (:ref:`time`): Duration of the pattern.
+            repeat (bool): Whether to keep repeating the pattern after it
+                completes.
+        """
+
 
 class ColorLight:
     """Control a multi-color light."""

--- a/pybricks/_common.py
+++ b/pybricks/_common.py
@@ -404,12 +404,13 @@ class Light:
         """Turns off the light."""
         pass
 
-    def pattern(self, pattern, duration, repeat=True):
+    def pattern(self, pattern, duration):
         """Make the light brightness follow a pattern as a function of time.
 
         The specified pattern function will be sampled at 64 points between 0
         and the specified duration. The light will be held at a constant
-        brightness between samples.
+        brightness between samples. After the given duration, the pattern
+        repeats.
 
         This function is not blocking. The pattern will be shown as the
         user program continues.
@@ -419,8 +420,6 @@ class Light:
                 form ``b = func(t)``` that returns the brightness ``b``
                 of the (0--100.0) as a function of time ``t`` in milliseconds.
             time (:ref:`time`): Duration of the pattern.
-            repeat (bool): Whether to keep repeating the pattern after it
-                completes.
         """
 
 
@@ -450,12 +449,12 @@ class ColorLight:
         """
         pass
 
-    def pattern(self, pattern, duration, repeat=True):
+    def pattern(self, pattern, duration):
         """Make the light follow a color pattern as a function of time.
 
         The specified pattern function will be sampled at 64 points between 0
         and the specified duration. The light will be held constant between
-        samples.
+        samples. After the given duration, the pattern repeats.
 
         This function is not blocking. The pattern will be shown as the
         user program continues.
@@ -467,8 +466,6 @@ class ColorLight:
                 Instead of an HSV tuple, you may return
                 a :class:`Button <.parameters.Color>` for simplicity.
             time (:ref:`time`): Duration of the pattern.
-            repeat (bool): Whether to keep repeating the pattern after it
-                completes.
         """
 
 

--- a/pybricks/_common.py
+++ b/pybricks/_common.py
@@ -405,20 +405,17 @@ class Light:
         pass
 
     def pattern(self, pattern, duration):
-        """Make the light brightness follow a pattern as a function of time.
+        """Makes the light brightness follow a pattern as a function of time.
 
         The specified pattern function will be sampled at 64 points between 0
         and the specified duration. The light will be held at a constant
         brightness between samples. After the given duration, the pattern
         repeats.
 
-        This function is not blocking. The pattern will be shown as the
-        user program continues.
-
         Arguments:
             pattern (callable): Function of the
-                form ``b = func(t)``` that returns the brightness ``b``
-                of the (0--100.0) as a function of time ``t`` in milliseconds.
+                form ``b = func(t)`` that returns the brightness ``b`` as a
+                function of time ``t`` in milliseconds.
             time (:ref:`time`): Duration of the pattern.
         """
 
@@ -445,7 +442,7 @@ class ColorLight:
         pass
 
     def hsv(self, hue, saturation=100, value=100):
-        """Set the hue, saturation and brightness of the light.
+        """Sets the hue, saturation and brightness of the light.
 
         Arguments:
             hue (:ref:`hue`): Hue of the color.
@@ -455,21 +452,19 @@ class ColorLight:
         pass
 
     def pattern(self, pattern, duration):
-        """Make the light follow a color pattern as a function of time.
+        """Makes the light follow a color pattern as a function of time.
 
         The specified pattern function will be sampled at 64 points between 0
         and the specified duration. The light will be held constant between
         samples. After the given duration, the pattern repeats.
 
-        This function is not blocking. The pattern will be shown as the
-        user program continues.
-
         Arguments:
             pattern (callable): Function of the
-                form ``h, s, v = func(t)``` that returns a tuple of ``h``,
+                form ``h, s, v = func(t)`` that returns a tuple of ``h``,
                 ``s``, and ``v`` as a function of time ``t`` in milliseconds.
-                Instead of an HSV tuple, you may return
-                a :class:`Button <.parameters.Color>` for simplicity.
+                A function of the
+                form :class:`col <.parameters.Color>` ``= func(t)`` is also
+                allowed.
             time (:ref:`time`): Duration of the pattern.
         """
 

--- a/pybricks/_common.py
+++ b/pybricks/_common.py
@@ -440,13 +440,13 @@ class ColorLight:
         """Turns off the light."""
         pass
 
-    def rgb(self, red, green, blue):
-        """Sets the brightness of the red, green, and blue light.
+    def hsv(self, hue, saturation=100, value=100):
+        """Set the hue, saturation and brightness of the light.
 
         Arguments:
-            red (:ref:`brightness`): Brightness of the red light.
-            green (:ref:`brightness`): Brightness of the green light.
-            blue (:ref:`brightness`): Brightness of the blue light.
+            hue (:ref:`angle`): Hue of the color.
+            saturation (:ref:`percentage`): Saturation of the color.
+            value (:ref:`percentage`): Brightness value of the color.
         """
         pass
 

--- a/pybricks/pupdevices.py
+++ b/pybricks/pupdevices.py
@@ -212,7 +212,7 @@ class ColorSensor:
 
         :returns: Tuple with the hue, saturation, and value
             (brightness) of the color.
-        :rtype: (:ref:`angle`, :ref:`percentage`, :ref:`percentage`)
+        :rtype: (:ref:`hue`, :ref:`percentage`, :ref:`percentage`)
 
         """
         pass


### PR DESCRIPTION
This PR is intended for some initial discussion regarding light and patterns. It provides a simple but very generic pattern and color interface, and keeps possible implementation considerations in mind. This adds finegrained color control as well as smooth or step-wise light and color patterns that run in the background.

This could essentially leverage existing `pbio` functionality, because the existing breathing pattern is implemented in a similar way. This proposal combines the benefits of Python (pattern is a callable) and efficiency in the C implementation (pre-allocated brightness samples).

The commit messages provide some examples to generate some discussion. It will eventually be moved to the docs.

It would only be implemented for internal hub lights, and possibly the powered up light.

This also makes a few minor modifications to the LightGrid() concept class which will be used by hubs that have one.