### PR TITLE
builtins: List decorators in separate section.

### DIFF
--- a/doc/main/micropython/builtins.rst
+++ b/doc/main/micropython/builtins.rst
@@ -93,8 +93,6 @@ Class-related functions
 
 .. autofunction:: ubuiltins.callable
 
-.. autofunction:: ubuiltins.classmethod
-
 .. autofunction:: ubuiltins.dir
 
 .. autofunction:: ubuiltins.getattr
@@ -106,8 +104,6 @@ Class-related functions
 .. autofunction:: ubuiltins.issubclass
 
 .. autofunction:: ubuiltins.setattr
-
-.. autofunction:: ubuiltins.staticmethod
 
 .. autofunction:: ubuiltins.super
 
@@ -135,3 +131,11 @@ Runtime-related functions
 .. autofunction:: ubuiltins.id
 
 .. autofunction:: ubuiltins.help
+
+
+Method decorators
+-----------------
+
+.. autodecorator:: ubuiltins.classmethod
+
+.. autodecorator:: ubuiltins.staticmethod


### PR DESCRIPTION
This moves the built-in decorators to their own section and uses `autodecorator` to indicate they are decorators.