### PR TITLE
pybricks.common: Refactored Speaker API to be hub specific.

### DIFF
--- a/doc/common/conf.py
+++ b/doc/common/conf.py
@@ -33,10 +33,6 @@ TOP_DIR = os.path.abspath(os.path.join('..', '..'))
 sys.path.insert(0, os.path.join(TOP_DIR, 'src'))
 sys.path.append(os.path.abspath('../common/extensions'))
 
-from pybricks.hubs import EV3Brick  # noqa E402
-from pybricks.media.ev3dev import Image  # noqa E402
-from pybricks._common import Speaker  # noqa E402
-
 # ON_RTD is whether we are on readthedocs.org
 # this line of code grabbed from docs.readthedocs.org
 ON_RTD = os.environ.get('READTHEDOCS', None) == 'True'

--- a/src/pybricks/_common.py
+++ b/src/pybricks/_common.py
@@ -420,65 +420,6 @@ class Speaker:
         """
         pass
 
-    def play_file(self, file):
-        """Plays a sound file.
-
-        Arguments:
-            file (str):
-                Path to the sound file, including the file extension.
-        """
-
-        pass
-
-    def say(self, text):
-        """Says a given text string.
-
-        You can configure the language and voice of the text using
-        :meth:`set_speech_options`.
-
-        Arguments:
-            text (str): What to say.
-        """
-
-        pass
-
-    def set_speech_options(self, language=None, voice=None, speed=None, pitch=None):
-        """Configures speech settings used by the :meth:`say` method.
-
-        Any option that is set to ``None`` will not be changed. If an option
-        is set to an invalid value :meth:`say` will use the default value
-        instead.
-
-        Arguments:
-            language (str):
-                Language of the text. For example, you can choose ``'en'``
-                (English) or ``'de'`` (German). [#espeak_lang]_
-            voice (str):
-                The voice to use. For example, you can choose ``'f1'`` (female
-                voice variant 1) or ``'m3'`` (male voice variant 3).
-                [#espeak_lang]_
-            speed (int):
-                Number of words per minute.
-            pitch (int):
-                Pitch (0 to 99). Higher numbers make the voice higher pitched
-                and lower numbers make the voice lower pitched.
-        """
-        pass
-
-    def set_volume(self, volume, which='_all_'):
-        """Sets the speaker volume.
-
-        Arguments:
-            volume (:ref:`percentage`):
-                Volume of the speaker.
-            which (str):
-                Which volume to set. ``'Beep'`` sets the volume for
-                :meth:`beep` and :meth:`play_notes`. ``'PCM'`` sets the volume
-                for :meth:`play_file` and :meth:`say`. ``'_all_'`` sets both
-                at the same time.
-        """
-        pass
-
 
 class Light:
     """Control a single-color light."""

--- a/src/pybricks/_common.pyi
+++ b/src/pybricks/_common.pyi
@@ -5,7 +5,7 @@ from typing import Collection, Iterable, Optional, Tuple, Union, overload
 
 from .geometry import Axis, Matrix, vector
 from .parameters import Button, Color, Direction, Side, Stop, Port
-from .media.ev3dev import SoundFile
+
 
 class DCMotor:
     def __init__(
@@ -83,16 +83,6 @@ class Motor(DCMotor):
 class Speaker:
     def beep(self, frequency: int = 500, duration: int = 100) -> None: ...
     def play_notes(self, notes: Iterable[str], tempo: int = 120) -> None: ...
-    def play_file(self, file_name: Union[SoundFile, str]) -> None: ...
-    def say(self, text: str) -> None: ...
-    def set_speech_options(
-        self,
-        language: Optional[str] = None,
-        voice: Optional[str] = None,
-        speed: Optional[int] = None,
-        pitch: Optional[int] = None,
-    ): ...
-    def set_volume(self, volume: int, which: str = "_all_") -> None: ...
 
 class Light:
     def on(self, brightness: int = 100) -> None: ...

--- a/src/pybricks/ev3dev/_speaker.py
+++ b/src/pybricks/ev3dev/_speaker.py
@@ -1,0 +1,112 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2018-2021 The Pybricks Authors
+
+
+class Speaker:
+    """Plays beeps and sounds using a speaker."""
+
+    def beep(self, frequency=500, duration=100):
+        """Play a beep/tone.
+
+        Arguments:
+            frequency (:ref:`frequency`):
+                Frequency of the beep. Frequencies below 100
+                are treated as 100.
+            duration (:ref:`time`):
+                Duration of the beep. If the duration is less
+                than 0, then the method returns immediately and the frequency
+                play continues to play indefinitely.
+        """
+        pass
+
+    def play_notes(self, notes, tempo=120):
+        """Plays a sequence of musical notes. For example:
+        ``['C4/4', 'C4/4', 'G4/4', 'G4/4']``.
+
+        Each note is a string with the following format:
+
+            - The first character is the name of the note, ``A`` to ``G``
+              or ``R`` for a rest.
+            - Note names can also include an accidental ``#`` (sharp) or
+              ``b`` (flat). ``B#``/``Cb`` and ``E#``/``Fb`` are not
+              allowed.
+            - The note name is followed by the octave number ``2``
+              to ``8``. For example ``C4`` is middle C. The octave changes
+              to the next number at the note C, for example, ``B3`` is the
+              note below middle C (``C4``).
+            - The octave is followed by ``/`` and a number that indicates
+              the size of the note. For example ``/4`` is a quarter note,
+              ``/8`` is an eighth note and so on.
+            - This can optionally followed by a ``.`` to make a dotted
+              note. Dotted notes are 1-1/2 times as long as notes without a
+              dot.
+            - The note can optionally end with a ``_`` which is a tie or a
+              slur. This causes there to be no pause between this note and
+              the next note.
+
+        Arguments:
+            notes (iter):
+                A sequence of notes to be played.
+            tempo (int):
+                Beats per minute. A quarter note is one beat.
+        """
+        pass
+
+    def play_file(self, file):
+        """Plays a sound file.
+
+        Arguments:
+            file (str):
+                Path to the sound file, including the file extension.
+        """
+
+        pass
+
+    def say(self, text):
+        """Says a given text string.
+
+        You can configure the language and voice of the text using
+        :meth:`set_speech_options`.
+
+        Arguments:
+            text (str): What to say.
+        """
+
+        pass
+
+    def set_speech_options(self, language=None, voice=None, speed=None, pitch=None):
+        """Configures speech settings used by the :meth:`say` method.
+
+        Any option that is set to ``None`` will not be changed. If an option
+        is set to an invalid value :meth:`say` will use the default value
+        instead.
+
+        Arguments:
+            language (str):
+                Language of the text. For example, you can choose ``'en'``
+                (English) or ``'de'`` (German). [#espeak_lang]_
+            voice (str):
+                The voice to use. For example, you can choose ``'f1'`` (female
+                voice variant 1) or ``'m3'`` (male voice variant 3).
+                [#espeak_lang]_
+            speed (int):
+                Number of words per minute.
+            pitch (int):
+                Pitch (0 to 99). Higher numbers make the voice higher pitched
+                and lower numbers make the voice lower pitched.
+        """
+        pass
+
+    def set_volume(self, volume, which='_all_'):
+        """Sets the speaker volume.
+
+        Arguments:
+            volume (:ref:`percentage`):
+                Volume of the speaker.
+            which (str):
+                Which volume to set. ``'Beep'`` sets the volume for
+                :meth:`beep` and :meth:`play_notes`. ``'PCM'`` sets the volume
+                for :meth:`play_file` and :meth:`say`. ``'_all_'`` sets both
+                at the same time.
+        """
+        pass

--- a/src/pybricks/ev3dev/_speaker.pyi
+++ b/src/pybricks/ev3dev/_speaker.pyi
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2020-2021 The Pybricks Authors
+
+from typing import Iterable, Optional, Union
+
+from pybricks.media.ev3dev import SoundFile
+
+
+class Speaker:
+    def beep(self, frequency: int = 500, duration: int = 100) -> None: ...
+    def play_notes(self, notes: Iterable[str], tempo: int = 120) -> None: ...
+    def play_file(self, file_name: Union[SoundFile, str]) -> None: ...
+    def say(self, text: str) -> None: ...
+    def set_speech_options(
+            self,
+            language: Optional[str] = None,
+            voice: Optional[str] = None,
+            speed: Optional[int] = None,
+            pitch: Optional[int] = None,
+    ): ...
+    def set_volume(self, volume: int, which: str = "_all_") -> None: ...

--- a/src/pybricks/hubs.py
+++ b/src/pybricks/hubs.py
@@ -7,9 +7,10 @@ from ._common import (Speaker as _Speaker, Battery as _Battery,
                       LightMatrix as _LightMatrix, IMU as _IMU,
                       System as _System,
                       SimpleAccelerometer as _SimpleAccelerometer)
+from .ev3dev._speaker import Speaker as _EV3Speaker
+from .geometry import Axis as _Axis
 from .media.ev3dev import Image as _Image
 from .parameters import Button as _Button
-from .geometry import Axis as _Axis
 
 
 class EV3Brick:
@@ -25,7 +26,7 @@ class EV3Brick:
         _Button.DOWN,
     ))
     screen = _Image('_screen_')
-    speaker = _Speaker()
+    speaker = _EV3Speaker()
     battery = _Battery()
     light = _ColorLight()
 

--- a/src/pybricks/hubs.pyi
+++ b/src/pybricks/hubs.pyi
@@ -2,12 +2,14 @@
 # Copyright (c) 2020 The Pybricks Authors
 
 from ._common import Speaker, Battery, ColorLight, LightMatrix, Keypad
-from .media.ev3dev import Image
+from .ev3dev._speaker import Speaker as EV3Speaker
 from .geometry import Axis
+from .media.ev3dev import Image
+
 
 class EV3Brick:
     screen: Image
-    speaker: Speaker
+    speaker: EV3Speaker
     battery: Battery
     light: ColorLight
     buttons = Keypad


### PR DESCRIPTION
The Prime/Inventor Hub Speaker allows only a subset of EV3 Speaker API. Hence, splitting the API up.