### PR TITLE
Fix wrong typing in pybricks.parameters.Stop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 ### Added
 - Code auto-completion for `EssentialHub`.
 
+### Fixed
+- Fixed some type hints in `parameters` submodule.
+
 ## 3.2.0b1-r3 - 2022-06-26
 
 ### Fixed

--- a/src/pybricks/parameters.py
+++ b/src/pybricks/parameters.py
@@ -131,13 +131,13 @@ class Port(_PybricksEnum):
 class Stop(_PybricksEnum):
     """Action after the motor stops."""
 
-    COAST: Port = 0
+    COAST: Stop = 0
     """Let the motor move freely."""
 
-    BRAKE: Port = 1
+    BRAKE: Stop = 1
     """Passively resist small external forces."""
 
-    HOLD: Port = 2
+    HOLD: Stop = 2
     """Keep controlling the motor to hold it at the commanded angle. This is
     only available on motors with encoders."""
 


### PR DESCRIPTION
David, Laurens,

I've found some minor wrong typing info.