### PR TITLE
doc/main/pupdevices/motor: Fix center example.

### DIFF
--- a/doc/main/pupdevices/motor.rst
+++ b/doc/main/pupdevices/motor.rst
@@ -163,7 +163,7 @@ Centering a steering mechanism
 *******************************************************
 
 .. literalinclude::
-    ../../../examples/pup/motor/motor_until_stalled.py
+    ../../../examples/pup/motor/motor_until_stalled_center.py
 
 
 Parallel movement examples


### PR DESCRIPTION
This fixes the include for the centering example to link it to the correct source file.

Fixes: https://github.com/pybricks/support/issues/734