### PR TITLE
doc/common/css/ide: improve styling of field list

### DIFF
--- a/doc/common/_static/css/ide.css
+++ b/doc/common/_static/css/ide.css
@@ -40,3 +40,11 @@
 ::-webkit-scrollbar-thumb:hover {
     background: #182026;
 }
+
+html.writer-html5 .rst-content dl.citation,
+html.writer-html5 .rst-content dl.field-list,
+html.writer-html5 .rst-content dl.footnote {
+    display: flex;
+    flex-direction: column;
+    grid-template-columns: unset;
+}


### PR DESCRIPTION
The default style of using a grid with two columns wastes space when displayed in a narrow pane, like in Pybricks Code. Using flex with column direction makes it flow from top to bottom.

Fixes: https://github.com/pybricks/support/issues/832