### PR TITLE
WIP: possible solution for awaitable functions

### DIFF
--- a/jedi/tests/test_get_signature.py
+++ b/jedi/tests/test_get_signature.py
@@ -429,13 +429,13 @@ METHOD_PARAMS = [
         "pybricks.hubs",
         "PrimeHub",
         "speaker.beep",
-        [(["frequency: Number=500", "duration: Number=100"], "None")],
+        [(["frequency: Number=500", "duration: Number=100"], "MaybeAsync")],
     ),
     pytest.param(
         "pybricks.hubs",
         "PrimeHub",
         "speaker.play_notes",
-        [(["notes: Iterable[str]", "tempo: Number=120"], "None")],
+        [(["notes: Iterable[str]", "tempo: Number=120"], "MaybeAsync")],
     ),
     pytest.param("pybricks.hubs", "PrimeHub", "battery.voltage", [([], "int")]),
     pytest.param("pybricks.hubs", "PrimeHub", "battery.current", [([], "int")]),
@@ -571,7 +571,7 @@ METHOD_PARAMS = [
                     "then: Stop=Stop.HOLD",
                     "wait: bool=True",
                 ],
-                "None",
+                "MaybeAsync",
             )
         ],
     ),
@@ -587,7 +587,7 @@ METHOD_PARAMS = [
                     "then: Stop=Stop.HOLD",
                     "wait: bool=True",
                 ],
-                "None",
+                "MaybeAsync",
             )
         ],
     ),
@@ -603,7 +603,7 @@ METHOD_PARAMS = [
                     "then: Stop=Stop.HOLD",
                     "wait: bool=True",
                 ],
-                "None",
+                "MaybeAsync",
             )
         ],
     ),
@@ -624,7 +624,7 @@ METHOD_PARAMS = [
                     "then: Stop=Stop.COAST",
                     "duty_limit: Optional[Number]=None",
                 ],
-                "int",
+                "MaybeAsyncInt",
             )
         ],
     ),

--- a/src/pybricks/_common.py
+++ b/src/pybricks/_common.py
@@ -12,7 +12,15 @@ from .tools import Matrix
 from .parameters import Axis, Direction, Stop, Button, Port, Color, Side
 
 if TYPE_CHECKING:
+    from typing import Awaitable
+
     from .parameters import Number
+
+    class MaybeAsync(None, Awaitable[None]):
+        ...
+
+    class MaybeAsyncInt(int, Awaitable[int]):
+        ...
 
 
 class System:
@@ -476,7 +484,7 @@ class Motor(DCMotor):
 
     def run_time(
         self, speed: Number, time: Number, then: Stop = Stop.HOLD, wait: bool = True
-    ) -> None:
+    ) -> MaybeAsync:
         """run_time(speed, time, then=Stop.HOLD, wait=True)
 
         Runs the motor at a constant speed for a given amount of time.
@@ -499,7 +507,7 @@ class Motor(DCMotor):
         rotation_angle: Number,
         then: Stop = Stop.HOLD,
         wait: bool = True,
-    ) -> None:
+    ) -> MaybeAsync:
         """run_angle(speed, rotation_angle, then=Stop.HOLD, wait=True)
 
         Runs the motor at a constant speed by a given angle.
@@ -519,7 +527,7 @@ class Motor(DCMotor):
         target_angle: Number,
         then: Stop = Stop.HOLD,
         wait: bool = True,
-    ) -> None:
+    ) -> MaybeAsync:
         """run_target(speed, target_angle, then=Stop.HOLD, wait=True)
 
         Runs the motor at a constant speed towards a given target angle.
@@ -540,7 +548,7 @@ class Motor(DCMotor):
         speed: Number,
         then: Stop = Stop.COAST,
         duty_limit: Optional[Number] = None,
-    ) -> int:
+    ) -> MaybeAsyncInt:
         """
         run_until_stalled(speed, then=Stop.COAST, duty_limit=None) -> int: deg
 
@@ -604,7 +612,7 @@ class Speaker:
             volume (Number, %): Volume of the speaker in the 0-100 range.
         """
 
-    def beep(self, frequency: Number = 500, duration: Number = 100) -> None:
+    def beep(self, frequency: Number = 500, duration: Number = 100) -> MaybeAsync:
         """beep(frequency=500, duration=100)
 
         Play a beep/tone.
@@ -618,7 +626,7 @@ class Speaker:
                 play continues to play indefinitely.
         """
 
-    def play_notes(self, notes: Iterable[str], tempo: Number = 120) -> None:
+    def play_notes(self, notes: Iterable[str], tempo: Number = 120) -> MaybeAsync:
         """play_notes(notes, tempo=120)
 
         Plays a sequence of musical notes. For example:


### PR DESCRIPTION
In our proposed multitasking framework, many blocking functions will become awaitable when running in an async run loop. So we need a way to give code completion tools to work in either case.

This introduces a pattern of a `MaybeAsync<Type>` where `MaybeAsync<Type>` inherits from both `<Type>` and `typing.Awaitable[<Type>]`. This way we get mostly proper completions for both `x = instance.method()` and `x = await instance.method()`.

As a bonus, it is also a nice way to very quickly know if a method should be awaited or not by just looking at the signature and not having to read the full documentation.

Note: I tried a generic:

```python
class MaybeAsync(_T, Awaitable[_T]): ...

class ...

    def method(self) -> MaybeAsync[int]: ...
```

But the code completion engines don't seem to be able to figure that one out, so it seems we will have to make our own type for each return type.