### PR TITLE
Specify order of geartrain in docs

### DIFF
--- a/src/pybricks/pupdevices.py
+++ b/src/pybricks/pupdevices.py
@@ -55,10 +55,13 @@ class Motor(_common.Motor):
                 turn when you give a positive speed value or
                 angle.
             gears (list):
-                List of gears linked to the motor.
+                List of gears linked to the motor, with the gear connected
+                to the motor listed and the gear connected to the output listed
+                last.
 
                 For example: ``[12, 36]`` represents a gear train with a
-                12-tooth and a 36-tooth gear. Use a list of lists for multiple
+                12-tooth gear connected to the motor and a 36-tooth gear
+                connected to the output. Use a list of lists for multiple
                 gear trains, such as ``[[12, 36], [20, 16, 40]]``.
 
                 When you specify a gear train, all motor commands and settings

--- a/src/pybricks/pupdevices.py
+++ b/src/pybricks/pupdevices.py
@@ -56,7 +56,7 @@ class Motor(_common.Motor):
                 angle.
             gears (list):
                 List of gears linked to the motor, with the gear connected
-                to the motor listed and the gear connected to the output listed
+                to the motor first and the gear connected to the output
                 last.
 
                 For example: ``[12, 36]`` represents a gear train with a


### PR DESCRIPTION
I found the gear documentation confusing because I didn't know whether the input or output gear should be listed first. I checked the C code and saw that it is the gear closest to the motor first, but I think it might be best to be explicit about it in documentation.