### PR TITLE
Robotics.py: Fix issue with the type stub for DriveBase.angle()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Fixed `DriveBase.angle` reporting an incorrect return type.
+
 ## 3.6.1 - 2025-05-01
 
 ### Fixed

--- a/jedi/tests/test_get_signature.py
+++ b/jedi/tests/test_get_signature.py
@@ -1020,7 +1020,7 @@ METHOD_PARAMS = [
     pytest.param("pybricks.robotics", "DriveBase", "stop", [([], "None")]),
     pytest.param("pybricks.robotics", "DriveBase", "brake", [([], "None")]),
     pytest.param("pybricks.robotics", "DriveBase", "distance", [([], "int")]),
-    pytest.param("pybricks.robotics", "DriveBase", "angle", [([], "int")]),
+    pytest.param("pybricks.robotics", "DriveBase", "angle", [([], "float")]),
     pytest.param(
         "pybricks.robotics", "DriveBase", "state", [([], "Tuple[int, int, int, int]")]
     ),

--- a/src/pybricks/robotics.py
+++ b/src/pybricks/robotics.py
@@ -101,8 +101,8 @@ class DriveBase:
             Driven distance since last reset.
         """
 
-    def angle(self) -> int:
-        """angle() -> int: deg
+    def angle(self) -> float:
+        """angle() -> float: deg
 
         Gets the estimated rotation angle of the drive base.
 


### PR DESCRIPTION
In the type stub for DriveBase.angle(), the return type was incorrectly reported as an integer despite actually returning a float. 