### PR TITLE
pybricks.parameters.Color: fix value for Color.NONE

### DIFF
--- a/doc/common/extensions/color.py
+++ b/doc/common/extensions/color.py
@@ -16,7 +16,7 @@ class PybricksColorDirective(Directive):
         color = getattr(Color, name)
 
         # Convert HSV to RGB
-        r, g, b = hsv_to_rgb(color.h / 360, color.s / 100, color.v / 100)
+        r, g, b = hsv_to_rgb(color.h / 360, color.s / 100, max(color.v, 0) / 100)
 
         # Convert RGB to HEX
         rgbhex = "#{0:02x}{1:02x}{2:02x}".format(

--- a/src/pybricks/parameters.py
+++ b/src/pybricks/parameters.py
@@ -135,7 +135,7 @@ class Color:
         return self.__mul__(1 / scale)
 
 
-Color.NONE = Color(0, 0, 0)
+Color.NONE = Color(0, 0, -40)
 Color.BLACK = Color(0, 0, 10)
 Color.GRAY = Color(0, 0, 50)
 Color.WHITE = Color(0, 0, 100)


### PR DESCRIPTION
It annoy me that the doc is not aligned on the real code, but maybe the negative value should not be public… What do you thing about it?

I did not manage to build the doc, some weird error about epub3 and imghdr.